### PR TITLE
Plone: Fix <style> / <link> order mixing

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,8 @@ Changelog
 1.0 (unreleased)
 ------------------
 
+- Plone: Fix <style> / <link> order mixing
+  [laulaz]
 - Bootstrap: handle error fields for z3cforms.
   [davidjb]
 - Bootstrap: convert ``submit-widget`` input buttons into primary buttons.

--- a/diazotheme/frameworks/plone/rules/head/theme.xml
+++ b/diazotheme/frameworks/plone/rules/head/theme.xml
@@ -4,11 +4,8 @@
          xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
          xmlns:xi="http://www.w3.org/2001/XInclude">
 
-  <!-- Links -->
-  <after css:theme="title" css:content="head link:not([rel*=icon])"/>
-
-  <!-- Style -->
-  <after css:theme="title" css:content="head style"/>
+  <!-- Links & Styles -->
+  <after css:theme="title" css:content="head link:not([rel*=icon]), head style"/>
 
   <!-- Scripts -->
   <after css:theme="title" css:content="head script"/>


### PR DESCRIPTION
We need to select link and style tags together to keep their order